### PR TITLE
Allow running STARsolo complex mode without barcode whitelist

### DIFF
--- a/docs/STARsolo.md
+++ b/docs/STARsolo.md
@@ -37,6 +37,7 @@ Running STARsolo for 10X Chromium scRNA-seq data
 * STARsolo is run the same way as normal STAR run, with addition of several STARsolo parameters:
     ```
    /path/to/STAR --genomeDir /path/to/genome/dir/ --readFilesIn ...  [...other parameters...] --soloType ... --soloCBwhitelist ...
+   (use `--soloCBwhitelist None` to disable whitelisting)
     ```
    The genome index is the same as for normal STAR runs. </br>
    The parameters required to run STARsolo on 10X Chromium data are described below:
@@ -344,7 +345,8 @@ soloType                    None
 
 soloCBwhitelist             -
     string(s): file(s) with whitelist(s) of cell barcodes. Only --soloType CB_UMI_Complex allows more than one whitelist file.
-                            None            ... no whitelist: all cell barcodes are allowed
+                            None            ... no whitelist: all cell barcodes are allowed. For complex barcodes this can be specified once
+                                             (e.g. `--soloCBwhitelist None`) or for each barcode segment.
 
 soloCBstart                 1
     int>0: cell barcode start base

--- a/source/ParametersSolo.cpp
+++ b/source/ParametersSolo.cpp
@@ -4,6 +4,7 @@
 #include "streamFuns.h"
 #include "SequenceFuns.h"
 #include "serviceFuns.cpp"
+#include <algorithm>
 
 #include <stdlib.h>
 
@@ -347,53 +348,65 @@ void ParametersSolo::initialize(Parameters *pPin)
         cbWLyes=true; 
     /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////    
     } else if (type==SoloTypes::CB_UMI_Complex) {//complex barcodes: multiple whitelist (one for each CB), varying CB length
-        cbWLyes=true; //for complex barcodes, no-whitelist option is not allowed for now
-        
+
         adapterYes=false;
         if (adapterSeq!="-")
             adapterYes=true;
-        
-        if (cbPositionStr.size() != soloCBwhitelist.size()) {
+
+        bool noWL = false;
+        if (soloCBwhitelist.size()==1 && soloCBwhitelist[0]=="None") {
+            noWL=true;
+        } else if (soloCBwhitelist.size()==cbPositionStr.size()) {
+            noWL = std::all_of(soloCBwhitelist.begin(), soloCBwhitelist.end(), [](const string &s){return s=="None";});
+        };
+
+        if (!noWL && cbPositionStr.size() != soloCBwhitelist.size()) {
             ostringstream errOut;
             errOut << "EXITING because of fatal PARAMETER error: number of barcodes in --soloCBposition : "<< cbPositionStr.size() <<" is not equal to the number of WhiteLists in --soloCBwhitelist : " << soloCBwhitelist.size() <<"\n"  ;
             errOut << "SOLUTION: make sure that the number of CB whitelists and CB positions are the same\n";
             exitWithError(errOut.str(),std::cerr, pP->inOut->logMain, EXIT_CODE_INPUT_FILES, *pP);
         };
+
+        cbWLyes = !noWL;
         cbV.resize(cbPositionStr.size());
         for (uint32 ii=0; ii<cbPositionStr.size(); ii++) {
             cbV[ii].extractPositionsFromString(cbPositionStr[ii]);
         };
-        
+
         umiV.extractPositionsFromString(umiPositionStr);
         umiL = 0; //this will be defined when the first barcode is processed
-              
+
         umiV.adapterLength=adapterSeq.size();//one adapter for all
-        cbWLsize=1;
-        for (uint32 icb=0; icb<cbV.size(); icb++) {//cycle over WL files
-            cbV[icb].adapterLength=adapterSeq.size();//one adapter for all
-            
-            ifstream & cbWlStream = ifstrOpen(soloCBwhitelist[icb], ERROR_OUT, "SOLUTION: check the path and permissions of the CB whitelist file: " + soloCBwhitelist[icb], *pP);
-            
-            string seq1;
-            while (cbWlStream >> seq1) {//cycle over one WL file
-                uint64 cb1;
-                if (!convertNuclStrToInt64(seq1,cb1)) {//convert to 2-bit format
-                    pP->inOut->logMain << "WARNING: CB whitelist sequence contains non-ACGT base and is ignored: " << seq1 <<endl;
-                    continue;
+        if (cbWLyes) {
+            cbWLsize=1;
+            for (uint32 icb=0; icb<cbV.size(); icb++) {//cycle over WL files
+                cbV[icb].adapterLength=adapterSeq.size();//one adapter for all
+
+                ifstream & cbWlStream = ifstrOpen(soloCBwhitelist[icb], ERROR_OUT, "SOLUTION: check the path and permissions of the CB whitelist file: " + soloCBwhitelist[icb], *pP);
+
+                string seq1;
+                while (cbWlStream >> seq1) {//cycle over one WL file
+                    uint64 cb1;
+                    if (!convertNuclStrToInt64(seq1,cb1)) {//convert to 2-bit format
+                        pP->inOut->logMain << "WARNING: CB whitelist sequence contains non-ACGT base and is ignored: " << seq1 <<endl;
+                        continue;
+                    };
+
+                    uint32 len1=seq1.size();
+                    if (len1>=cbV[icb].wl.size())
+                        cbV[icb].wl.resize(len1+1);//add new possible lengths to this CB
+                    cbV[icb].wl.at(len1).push_back(cb1);
                 };
-                
-                uint32 len1=seq1.size();
-                if (len1>=cbV[icb].wl.size())
-                    cbV[icb].wl.resize(len1+1);//add new possible lengths to this CB
-                cbV[icb].wl.at(len1).push_back(cb1);
+
+                cbV[icb].sortWhiteList(this);
+                cbV[icb].wlFactor=cbWLsize;
+                cbWLsize *= cbV[icb].totalSize;
             };
-            
-            cbV[icb].sortWhiteList(this);
-            cbV[icb].wlFactor=cbWLsize;
-            cbWLsize *= cbV[icb].totalSize;
+
+            complexWLstrings();
+        } else {
+            cbWLsize = 0;
         };
-        
-        complexWLstrings();
     };
 
     time_t rawTime;

--- a/source/SoloReadBarcode_getCBandUMI.cpp
+++ b/source/SoloReadBarcode_getCBandUMI.cpp
@@ -360,66 +360,95 @@ void SoloReadBarcode::getCBandUMI(char **readSeq, char **readQual, uint64 *readL
         };
 
         cbMatchInd={0};
-        for (auto &cb : pSolo.cbV) {//cycle over multiple barcodes
-            
-            string cbSeq1, cbQual1;
-            if ( !cb.extractBarcode(bSeq, bQual, adapterStart, cbSeq1, cbQual1) 
-                 || cbSeq1.size() < cb.minLen || cbSeq1.size() >= cb.wl.size() || cb.wl[cbSeq1.size()].size()==0 ) {
-                //barcode cannot be extracted
-                if (cbMatchGood) {
-                    cbMatch=-11;
-                    cbMatchGood=false;
-                };
-            };
-            cbSeq  += cbSeq1 + "_";
-            cbQual += cbQual1 + "_";
-            
-            if (!cbMatchGood)
-                continue; //continue - to be able to record full cbSeq, cbQual, but no need to match to the WL
-            
-            uint64 cbLen1 = cbSeq1.size();
-            if ( pSolo.CBmatchWL.EditDist_2 ) {
-                cbMatch=0; //0: no MM, 1: >=1MM. 2: multi-match: not allowed for this option
-                uintCB cbB1;
-                int64 posN=convertNuclStrToInt64(cbSeq1,cbB1);
-                if (posN!=-1) {//Ns in barcode: no good match
-                    cbMatch = -2;
-                    cbMatchGood = false;
-                } else {
-                    int64 cbI=binarySearchExact<uint64>(cbB1,cb.wl[cbSeq1.size()].data(),cb.wl[cbLen1].size());
-                    if (cbI>=0) {//exact match
-                        cbMatchInd[0] += cb.wlFactor*(cbI+cb.wlAdd[cbLen1]);
-                    } else {//no exact match
-                        cbI=binarySearchExact<uint64>(cbB1,cb.wlEd[cbLen1].data(),cb.wlEd[cbLen1].size());
-                        if (cbI>=0) {//find match in the edited list
-                            cbMatch = 1; //>=1MM
-                            cbI = cb.wlEdInd[cbLen1][cbI];
-                            cbMatchInd[0] += cb.wlFactor*(cbI+cb.wlAdd[cbLen1]);
-                        } else {
-                            cbMatch = -1;
-                            cbMatchGood = false;
-                        };
+        if (pSolo.cbWLyes) {
+            for (auto &cb : pSolo.cbV) {//cycle over multiple barcodes
+
+                string cbSeq1, cbQual1;
+                if ( !cb.extractBarcode(bSeq, bQual, adapterStart, cbSeq1, cbQual1)
+                     || cbSeq1.size() < cb.minLen || cbSeq1.size() >= cb.wl.size() || cb.wl[cbSeq1.size()].size()==0 ) {
+                    //barcode cannot be extracted
+                    if (cbMatchGood) {
+                        cbMatch=-11;
+                        cbMatchGood=false;
                     };
                 };
-            } else {// Exact or 1MM
-                int32 cbMatch1;
-                vector<uint64> cbMatchInd1;
-                matchCBtoWL(cbSeq1, cbQual1, cb.wl[cbLen1], cbMatch1, cbMatchInd1, cbMatchString); //cbMatchString is not used for now, multiple matches are not allowed
-                if (cbMatch1<0) {//no match
-                    cbMatchGood=false;
-                    cbMatch = cbMatch1;
-                } else if (cbMatch1>0 && cbMatch>0) {//this barcode has >1 1MM match, or previous barcode had a mismatch
-                    cbMatchGood=false;
-                    cbMatch = -12; //marks mismatches in multiple barcodes
-                } else {//good match
-                    cbMatchInd[0] += cb.wlFactor*(cbMatchInd1[0]+cb.wlAdd[cbLen1]);
-                    cbMatch=max(cbMatch,cbMatch1);//1 wins over 0
+                cbSeq  += cbSeq1 + "_";
+                cbQual += cbQual1 + "_";
+
+                if (!cbMatchGood)
+                    continue; //continue - to be able to record full cbSeq, cbQual, but no need to match to the WL
+
+                uint64 cbLen1 = cbSeq1.size();
+                if ( pSolo.CBmatchWL.EditDist_2 ) {
+                    cbMatch=0; //0: no MM, 1: >=1MM. 2: multi-match: not allowed for this option
+                    uintCB cbB1;
+                    int64 posN=convertNuclStrToInt64(cbSeq1,cbB1);
+                    if (posN!=-1) {//Ns in barcode: no good match
+                        cbMatch = -2;
+                        cbMatchGood = false;
+                    } else {
+                        int64 cbI=binarySearchExact<uint64>(cbB1,cb.wl[cbSeq1.size()].data(),cb.wl[cbLen1].size());
+                        if (cbI>=0) {//exact match
+                            cbMatchInd[0] += cb.wlFactor*(cbI+cb.wlAdd[cbLen1]);
+                        } else {//no exact match
+                            cbI=binarySearchExact<uint64>(cbB1,cb.wlEd[cbLen1].data(),cb.wlEd[cbLen1].size());
+                            if (cbI>=0) {//find match in the edited list
+                                cbMatch = 1; //>=1MM
+                                cbI = cb.wlEdInd[cbLen1][cbI];
+                                cbMatchInd[0] += cb.wlFactor*(cbI+cb.wlAdd[cbLen1]);
+                            } else {
+                                cbMatch = -1;
+                                cbMatchGood = false;
+                            };
+                        };
+                    };
+                } else {// Exact or 1MM
+                    int32 cbMatch1;
+                    vector<uint64> cbMatchInd1;
+                    matchCBtoWL(cbSeq1, cbQual1, cb.wl[cbLen1], cbMatch1, cbMatchInd1, cbMatchString); //cbMatchString is not used for now, multiple matches are not allowed
+                    if (cbMatch1<0) {//no match
+                        cbMatchGood=false;
+                        cbMatch = cbMatch1;
+                    } else if (cbMatch1>0 && cbMatch>0) {//this barcode has >1 1MM match, or previous barcode had a mismatch
+                        cbMatchGood=false;
+                        cbMatch = -12; //marks mismatches in multiple barcodes
+                    } else {//good match
+                        cbMatchInd[0] += cb.wlFactor*(cbMatchInd1[0]+cb.wlAdd[cbLen1]);
+                        cbMatch=max(cbMatch,cbMatch1);//1 wins over 0
+                    };
                 };
             };
+        } else {
+            uint32 cbShift=0;
+            for (auto &cb : pSolo.cbV) {
+                string cbSeq1, cbQual1;
+                if ( !cb.extractBarcode(bSeq, bQual, adapterStart, cbSeq1, cbQual1) ) {
+                    if (cbMatchGood) {
+                        cbMatch=-11;
+                        cbMatchGood=false;
+                    };
+                };
+                cbSeq  += cbSeq1 + "_";
+                cbQual += cbQual1 + "_";
+                if (!cbMatchGood)
+                    continue;
+                uint64 cbB1;
+                int64 posN = convertNuclStrToInt64(cbSeq1, cbB1);
+                if (posN!=-1) {
+                    cbMatch=-2;
+                    cbMatchGood=false;
+                } else {
+                    cbMatchInd[0] |= cbB1<<cbShift;
+                    cbShift += cbSeq1.size()*2;
+                };
+            };
+            if (cbShift==0) cbMatchGood=false; //no barcode extracted
+            if (cbMatchGood)
+                cbMatch=0;
         };
         cbSeq.pop_back();//remove last "_" from file
         cbQual.pop_back();
-        
+
         if (cbMatchGood) {
             cbMatchString=to_string(cbMatchInd[0]);
         };


### PR DESCRIPTION
## Summary
- support `--soloType CB_UMI_Complex` without providing whitelist files
- document that `--soloCBwhitelist None` disables whitelisting

## Testing
- `make STAR`

------
https://chatgpt.com/codex/tasks/task_e_68874325d58c8333bd067c72dbca7723